### PR TITLE
Settings: Fix findPeakRefreshRate logic

### DIFF
--- a/src/com/android/settings/development/ForcePeakRefreshRatePreferenceController.java
+++ b/src/com/android/settings/development/ForcePeakRefreshRatePreferenceController.java
@@ -121,9 +121,13 @@ public class ForcePeakRefreshRatePreferenceController extends DeveloperOptionsPr
 
     private float findPeakRefreshRate(Display.Mode[] modes) {
         float peakRefreshRate = DEFAULT_REFRESH_RATE;
+        float defaultPeakRefreshRate = (float) mContext.getResources().getInteger(
+                    com.android.internal.R.integer.config_defaultPeakRefreshRate);
         for (Display.Mode mode : modes) {
-            if (Math.round(mode.getRefreshRate()) > peakRefreshRate) {
-                peakRefreshRate = mode.getRefreshRate();
+            float refreshRate = Math.round(mode.getRefreshRate());
+            if (refreshRate > peakRefreshRate
+                    && (defaultPeakRefreshRate == 0 || refreshRate <= defaultPeakRefreshRate)) {
+                peakRefreshRate = refreshRate;
             }
         }
 

--- a/src/com/android/settings/display/PeakRefreshRatePreferenceController.java
+++ b/src/com/android/settings/display/PeakRefreshRatePreferenceController.java
@@ -143,9 +143,13 @@ public class PeakRefreshRatePreferenceController extends TogglePreferenceControl
     @VisibleForTesting
     float findPeakRefreshRate(Display.Mode[] modes) {
         float peakRefreshRate = DEFAULT_REFRESH_RATE;
+        float defaultPeakRefreshRate = (float) mContext.getResources().getInteger(
+                    com.android.internal.R.integer.config_defaultPeakRefreshRate);
         for (Display.Mode mode : modes) {
-            if (Math.round(mode.getRefreshRate()) > peakRefreshRate) {
-                peakRefreshRate = mode.getRefreshRate();
+            float refreshRate = Math.round(mode.getRefreshRate());
+            if (refreshRate > peakRefreshRate
+                    && (defaultPeakRefreshRate == 0 || refreshRate <= defaultPeakRefreshRate)) {
+                peakRefreshRate = refreshRate;
             }
         }
         return peakRefreshRate;


### PR DESCRIPTION
 * findPeakRefreshRate(display.getSupportedModes()) would return the panels max supported refresh rate and not the one set in config_defaultPeakRefreshRate resulting it to basically ignore that overlay
 * this way it uses the highest available refresh rate if config_defaultPeakRefreshRate is not defined, otherwise it will take the highest available value up to the specified value in that overlay

Change-Id: If515ff4ca972e0582e88330474b251d83246918f